### PR TITLE
Add max clique approx. paper reference

### DIFF
--- a/src/ComplexNetsGui/src/mainwindow.cpp
+++ b/src/ComplexNetsGui/src/mainwindow.cpp
@@ -538,9 +538,12 @@ void MainWindow::on_actionMaxClique_generic_triggered(bool exact)
         std::string key = exact ? "maxCliqueExact" : "maxCliqueAprox";
         int maxCliqueSize = propertyMap.getProperty<int>(key, "size");
         std::list<int> list = propertyMap.getProperty<std::list<int>>(key, "list");
-        ui->textBrowser->append(exact ? "Exact Max clique" : "Aprox Max clique");
-        ret.append(" size is: ").append(to_string<int>(maxCliqueSize).c_str()).append(".\n");
-        ret.append("clique is: ");
+        ui->textBrowser->append(exact ? "Exact Max clique" : "Aprox Max clique"
+                                "\nReference: José Ignacio Alvarez-Hamelin. "
+                                "Is it possible to find the maximum clique in general graphs? "
+                                "arXiv e-print, abs/1110.5355, Oct 2011.");
+        ret.append("Size is: ").append(to_string<int>(maxCliqueSize).c_str()).append(".\n");
+        ret.append("Clique is: ");
         for (const auto& elem : list)
         {
             ret.append(to_string<int>(elem).c_str()).append(" ");


### PR DESCRIPTION
## Summary
When using **Approx. Max Clique** the paper reference is now shown.

## Example
[<img width="599" alt="screen shot 2018-05-19 at 12 52 48" src="https://user-images.githubusercontent.com/9052089/40270584-4b8a7fea-5b66-11e8-972a-2fa88ba9514f.png">](url)