### PR TITLE
Fix dependency on id number in nearest neighbor degree calculation

### DIFF
--- a/src/ComplexNets/AdjacencyListGraph.h
+++ b/src/ComplexNets/AdjacencyListGraph.h
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <iostream>
 #include <memory>
+#include <climits>
 #include "GraphExceptions.h"
 #include "mili/mili.h"
 
@@ -185,6 +186,26 @@ public:
     Vertex* getVertexById(VertexId id) const
     {
         return VertexFinder<Vertex, VertexContainer>::find(id, vertices);
+    }
+
+    /**
+     * Method: getMinVertexId
+     * ----------------------
+     * Description: obtains the minimum vertex id in the graph.
+     * @return the minimum vertex id in the graph
+     */
+    VertexId getMinVertexId() const
+    {
+        VertexId currMin = UINT_MAX;
+        VerticesConstIterator it = verticesConstIterator();
+        while(!it.end()) {
+            VertexId currId = (*it) -> getVertexId();
+            if(currId < currMin) {
+                currMin = currId;
+            }
+            it++;
+        }
+        return currMin;
     }
 
     /**

--- a/src/ComplexNets/AdjacencyListGraph.h
+++ b/src/ComplexNets/AdjacencyListGraph.h
@@ -5,9 +5,9 @@
 #pragma once
 
 #include <algorithm>
+#include <climits>
 #include <iostream>
 #include <memory>
-#include <climits>
 #include "GraphExceptions.h"
 #include "mili/mili.h"
 
@@ -198,9 +198,11 @@ public:
     {
         VertexId currMin = UINT_MAX;
         VerticesConstIterator it = verticesConstIterator();
-        while(!it.end()) {
-            VertexId currId = (*it) -> getVertexId();
-            if(currId < currMin) {
+        while (!it.end())
+        {
+            VertexId currId = (*it)->getVertexId();
+            if (currId < currMin)
+            {
                 currMin = currId;
             }
             it++;
@@ -288,4 +290,4 @@ private:
     bool _isMultigraph;
     VertexContainer vertices;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/AdjacencyListVertex.h
+++ b/src/ComplexNets/AdjacencyListVertex.h
@@ -24,9 +24,7 @@ public:
     using VerticesConstIterator = CAutonomousIterator<VertexContainer>;
     using VerticesIterator = AutonomousIterator<VertexContainer>;
 
-    AdjacencyListVertex(VertexId id) : vertexId(id), visited(false)
-    {
-    }
+    AdjacencyListVertex(VertexId id) : vertexId(id), visited(false) {}
 
     /**
      * Method: addEdge
@@ -138,4 +136,4 @@ private:
     VertexId vertexId;
     bool visited;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/Betweenness.h
+++ b/src/ComplexNets/Betweenness.h
@@ -126,4 +126,4 @@ private:
 
     BetweennessContainer betweenness;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/Boxplotentry.h
+++ b/src/ComplexNets/Boxplotentry.h
@@ -37,4 +37,4 @@ public:
         return ss.str();
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/ClusteringCoefficient.h
+++ b/src/ComplexNets/ClusteringCoefficient.h
@@ -66,4 +66,4 @@ public:
         return ret;
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/ConnectivityVerifier.h
+++ b/src/ComplexNets/ConnectivityVerifier.h
@@ -22,9 +22,7 @@ public:
     std::list<unsigned int> vertexesLeft;
     std::list<unsigned int> vertexesInComponent;
 
-    ConnectivityVerifier()
-    {
-    }
+    ConnectivityVerifier() {}
 
     void visited(unsigned int id)
     {
@@ -70,9 +68,7 @@ template <class Graph, class Vertex>
 class ConnectivityVisitor
 {
 public:
-    ConnectivityVisitor(ConnectivityVerifier<Graph, Vertex>* observer) : observer(observer)
-    {
-    }
+    ConnectivityVisitor(ConnectivityVerifier<Graph, Vertex>* observer) : observer(observer) {}
 
     /**
      * Method: visitVertex
@@ -90,4 +86,4 @@ public:
 private:
     ConnectivityVerifier<Graph, Vertex>* observer;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/DegreeDistribution.h
+++ b/src/ComplexNets/DegreeDistribution.h
@@ -79,4 +79,4 @@ private:
 
     DistributionContainer distribution;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/DirectedClusteringCoefficient.h
+++ b/src/ComplexNets/DirectedClusteringCoefficient.h
@@ -153,4 +153,4 @@ public:
         return vertexClusteringCoefficient(vertex, false, false);
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/DirectedDegreeDistribution.h
+++ b/src/ComplexNets/DirectedDegreeDistribution.h
@@ -118,4 +118,4 @@ private:
     DistributionContainer outDegreeDistribution;
     DistributionContainer inOutDegreeDistribution;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/DirectedGraphAspect.h
+++ b/src/ComplexNets/DirectedGraphAspect.h
@@ -37,4 +37,4 @@ public:
         }
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/DirectedGraphFactory.h
+++ b/src/ComplexNets/DirectedGraphFactory.h
@@ -56,4 +56,4 @@ public:
         return nullptr;
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/DirectedNearestNeighborsDegree.h
+++ b/src/ComplexNets/DirectedNearestNeighborsDegree.h
@@ -111,4 +111,4 @@ public:
         return meanDegreeForVertex(v, false, false);
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/DirectedVertexAspect.h
+++ b/src/ComplexNets/DirectedVertexAspect.h
@@ -14,9 +14,7 @@ public:
     typedef AdjacencyListVertex::VerticesConstIterator VerticesConstIterator;
     typedef AdjacencyListVertex::VerticesIterator VerticesIterator;
 
-    DirectedVertexAspect(VertexId id) : T(id)
-    {
-    }
+    DirectedVertexAspect(VertexId id) : T(id) {}
 
     void addEdge(DirectedVertexAspect<T>* other)
     {
@@ -82,4 +80,4 @@ private:
     VertexContainer inNeighbors;
     VertexContainer outNeighbors;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/GraphFactory.h
+++ b/src/ComplexNets/GraphFactory.h
@@ -53,4 +53,4 @@ public:
         return nullptr;
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/GraphGenerator.cpp
+++ b/src/ComplexNets/GraphGenerator.cpp
@@ -248,9 +248,9 @@ void GraphGenerator::addFKPNode(
     {  // this for evaluated "w" for each vertex already in the graph
         unsigned hopsDistance = graph->hops(
             graph->getVertexById(j),
-            graph->getVertexById(root)
-        );  // distance between vertex evaluated and root vertex
-        float euclidianDistance = distanceBetweenVertex(j, vertexIndex);  // Distance between vertex evaluated and new vertex
+            graph->getVertexById(root));  // distance between vertex evaluated and root vertex
+        float euclidianDistance = distanceBetweenVertex(
+            j, vertexIndex);  // Distance between vertex evaluated and new vertex
 
         // Original FKP Algorithm chooses a new connection between the new vertex and the one with
         // minimum W
@@ -368,7 +368,7 @@ void GraphGenerator::addEdges(
     std::vector<unsigned int>* vertexIndexes)
 {
     for (unsigned int k = 0; k < q && !distance.empty(); k++)
-    {   // Adding "q" new edges. The processes is similar to added vertex.
+    {  // Adding "q" new edges. The processes is similar to added vertex.
         if (!graph->getVertexById(distance.begin()->second)->isNeighbourOf(vertex))
         {
             vertexIndexes->push_back(distance.begin()->second);

--- a/src/ComplexNets/GraphReader.h
+++ b/src/ComplexNets/GraphReader.h
@@ -129,4 +129,4 @@ private:
     LineNumber currentLineNumber;
     const char* character;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/IBetweenness.h
+++ b/src/ComplexNets/IBetweenness.h
@@ -17,8 +17,6 @@ public:
     typedef AutonomousIterator<BetweennessContainer> BetweennessIterator;
     virtual BetweennessIterator iterator() = 0;
 
-    virtual ~IBetweenness()
-    {
-    }
+    virtual ~IBetweenness() {}
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/IClusteringCoefficient.h
+++ b/src/ComplexNets/IClusteringCoefficient.h
@@ -24,8 +24,6 @@ public:
         return clusteringCoefficient(g, d);
     }
 
-    virtual ~IClusteringCoefficient()
-    {
-    }
+    virtual ~IClusteringCoefficient() {}
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/IDegreeDistribution.h
+++ b/src/ComplexNets/IDegreeDistribution.h
@@ -13,8 +13,6 @@ public:
 
     virtual DistributionIterator iterator() = 0;
 
-    virtual ~IDegreeDistribution()
-    {
-    }
+    virtual ~IDegreeDistribution() {}
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/IGraphFactory.h
+++ b/src/ComplexNets/IGraphFactory.h
@@ -33,8 +33,6 @@ public:
 
     virtual MaxCliqueExact<Graph, Vertex>* createExactMaxClique(Graph& g, int max_time) = 0;
 
-    virtual ~IGraphFactory()
-    {
-    }
+    virtual ~IGraphFactory() {}
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/IGraphReader.h
+++ b/src/ComplexNets/IGraphReader.h
@@ -37,8 +37,6 @@ public:
     typedef unsigned int LineNumber;
     virtual void read(Graph& g, std::string source) = 0;
 
-    virtual ~IGraphReader()
-    {
-    }
+    virtual ~IGraphReader() {}
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/IMaxClique.h
+++ b/src/ComplexNets/IMaxClique.h
@@ -15,4 +15,4 @@ public:
 
     virtual ~IMaxClique() = default;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/INearestNeighborsDegree.h
+++ b/src/ComplexNets/INearestNeighborsDegree.h
@@ -21,8 +21,6 @@ public:
         return meanDegreeForVertex(vertex);
     }
 
-    virtual ~INearestNeighborsDegree()
-    {
-    }
+    virtual ~INearestNeighborsDegree() {}
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/IShellIndex.h
+++ b/src/ComplexNets/IShellIndex.h
@@ -11,8 +11,6 @@ public:
 
     virtual ShellIndexIterator iterator() = 0;
 
-    virtual ~IShellIndex()
-    {
-    }
+    virtual ~IShellIndex() {}
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/IWeightedBetweenness.h
+++ b/src/ComplexNets/IWeightedBetweenness.h
@@ -17,4 +17,4 @@ public:
     typedef AutonomousIterator<BetweennessContainer> BetweennessIterator;
     virtual BetweennessIterator iterator() = 0;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/IntegerDistribution.h
+++ b/src/ComplexNets/IntegerDistribution.h
@@ -61,4 +61,4 @@ private:
 
     DistributionContainer distribution;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/MaxClique.h
+++ b/src/ComplexNets/MaxClique.h
@@ -15,9 +15,7 @@ template <class Graph, class Vertex>
 class MaxCliqueVisitor
 {
 public:
-    MaxCliqueVisitor(MaxClique<Graph, Vertex>& observer) : maxCliqueObserver(observer)
-    {
-    }
+    MaxCliqueVisitor(MaxClique<Graph, Vertex>& observer) : maxCliqueObserver(observer) {}
 
     bool visitVertex(Vertex* vertex)
     {
@@ -33,9 +31,7 @@ template <class Graph, class Vertex>
 class MaxCliqueMap
 {
 public:
-    MaxCliqueMap(MaxClique<Graph, Vertex>& observer) : maxCliqueObserver(observer)
-    {
-    }
+    MaxCliqueMap(MaxClique<Graph, Vertex>& observer) : maxCliqueObserver(observer) {}
 
     int get(Vertex* vertex)
     {
@@ -97,7 +93,7 @@ public:
                     Vertex* i = *it2;
                     if (i->getVisited())
                     {
-                        auto * L = new LSet();
+                        auto* L = new LSet();
 
                         if (as[x] == nullptr || (*as[x])[i] == nullptr)
                         {
@@ -156,7 +152,7 @@ public:
     int getMaxCliqueSize(Vertex* vertex)
     {
         unsigned int max_size = 0;
-        auto * ids = new std::list<int>();
+        auto* ids = new std::list<int>();
         for (AttributeIterator iterator2 = as[vertex]->begin(); iterator2 != as[vertex]->end();
              iterator2++)
         {
@@ -203,7 +199,8 @@ private:
     void calculateMaxClique(Graph& graph)
     {
         MaxCliqueVisitor<Graph, Vertex> visitor(*this);
-        TraverserOrdered<Graph, Vertex, MaxCliqueVisitor<Graph, Vertex>, DegreeCompare>::traverse(graph, visitor, DegreeCompare());
+        TraverserOrdered<Graph, Vertex, MaxCliqueVisitor<Graph, Vertex>, DegreeCompare>::traverse(
+            graph, visitor, DegreeCompare());
 
         MaxCliqueMap<Graph, Vertex> map(*this);
         distribution.calculateDistribution(graph, &map);
@@ -250,9 +247,7 @@ template <class Graph, class Vertex>
 class MaxCliqueExactVisitor
 {
 public:
-    MaxCliqueExactVisitor(MaxCliqueExact<Graph, Vertex>& observer) : maxCliquenObserver(observer)
-    {
-    }
+    MaxCliqueExactVisitor(MaxCliqueExact<Graph, Vertex>& observer) : maxCliquenObserver(observer) {}
 
     bool visitVertex(Vertex* vertex)
     {
@@ -274,9 +269,7 @@ template <class Graph, class Vertex>
 class MaxCliqueExactMap
 {
 public:
-    MaxCliqueExactMap(MaxCliqueExact<Graph, Vertex>& observer) : maxCliqueObserver(observer)
-    {
-    }
+    MaxCliqueExactMap(MaxCliqueExact<Graph, Vertex>& observer) : maxCliqueObserver(observer) {}
 
     int get(Vertex* vertex)
     {
@@ -535,7 +528,7 @@ public:
     bool timeouted;
     int start;
 };
-}
+}  // namespace graphpp
 /*
         linea de commandos
         tiempo para exacto

--- a/src/ComplexNets/MolloyReedGraphReader.h
+++ b/src/ComplexNets/MolloyReedGraphReader.h
@@ -440,4 +440,4 @@ private:
     LineNumber currentLineNumber;
     const char* character;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/NearestNeighborsDegree.h
+++ b/src/ComplexNets/NearestNeighborsDegree.h
@@ -47,4 +47,4 @@ public:
         return v->degree() == 0 ? 0 : double(degreeSum) / v->degree();
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/PropertyMap.h
+++ b/src/ComplexNets/PropertyMap.h
@@ -65,4 +65,4 @@ public:
 private:
     Properties properties;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/ShellIndex.h
+++ b/src/ComplexNets/ShellIndex.h
@@ -151,4 +151,4 @@ private:
     std::list<Node*>* nodesByCurrentDegree;
     int totalVertexes;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/StrengthDistribution.h
+++ b/src/ComplexNets/StrengthDistribution.h
@@ -72,9 +72,7 @@ public:
             distribution[d] = 1;
     }
 
-    virtual ~StrengthDistribution()
-    {
-    }
+    virtual ~StrengthDistribution() {}
 
 private:
     void calculateDistribution(Graph& graph)
@@ -86,4 +84,4 @@ private:
 
     DistributionContainer distribution;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/TraverserBFS.h
+++ b/src/ComplexNets/TraverserBFS.h
@@ -63,4 +63,4 @@ public:
         }
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/TraverserForward.h
+++ b/src/ComplexNets/TraverserForward.h
@@ -23,4 +23,4 @@ public:
         }
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/TraverserOrdered.h
+++ b/src/ComplexNets/TraverserOrdered.h
@@ -14,8 +14,9 @@ public:
     typedef typename VertexList::iterator VertexListIterator;
 
     /**
-     * Visit the vertexes in the graph in the order specified by the comparator in a decreasing order.
-     * All the vertexes may not be visited if the visitor decides it in the current vertex visit.
+     * Visit the vertexes in the graph in the order specified by the comparator in a decreasing
+     * order. All the vertexes may not be visited if the visitor decides it in the current vertex
+     * visit.
      * @param graph         the graph with the vertexes to traverse
      * @param visitor       the vertexes visitor
      * @param comparator    defines the order in which the vertexes will be visited
@@ -28,7 +29,8 @@ public:
         {
             Vertex* v = *vertexesIt;
             VertexListIterator orderedVertexesIt = orderedVertexes.begin();
-            while ((orderedVertexesIt != orderedVertexes.end()) && comparator(v, (*orderedVertexesIt)))
+            while ((orderedVertexesIt != orderedVertexes.end()) &&
+                   comparator(v, (*orderedVertexesIt)))
             {
                 orderedVertexesIt++;
             }
@@ -62,4 +64,4 @@ public:
         }
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/WeightedBetweenness.h
+++ b/src/ComplexNets/WeightedBetweenness.h
@@ -232,4 +232,4 @@ private:
 
     BetweennessContainer betweenness;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/WeightedClusteringCoefficient.h
+++ b/src/ComplexNets/WeightedClusteringCoefficient.h
@@ -63,4 +63,4 @@ public:
         return ret;
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/WeightedGraphAspect.h
+++ b/src/ComplexNets/WeightedGraphAspect.h
@@ -18,8 +18,6 @@ public:
         s->addEdge(d, weight);
         if (!this->isDigraph())
             d->addEdge(s, weight);
-        // s->addEdge(d, weight);
-        // d->addEdge(s, weight);
     }
 };
 }

--- a/src/ComplexNets/WeightedGraphAspect.h
+++ b/src/ComplexNets/WeightedGraphAspect.h
@@ -20,4 +20,4 @@ public:
             d->addEdge(s, weight);
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/WeightedGraphFactory.h
+++ b/src/ComplexNets/WeightedGraphFactory.h
@@ -56,4 +56,4 @@ public:
         return nullptr;
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/WeightedGraphReader.h
+++ b/src/ComplexNets/WeightedGraphReader.h
@@ -166,4 +166,4 @@ private:
     LineNumber currentLineNumber;
     const char* character;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/WeightedNearestNeighborsDegree.h
+++ b/src/ComplexNets/WeightedNearestNeighborsDegree.h
@@ -47,4 +47,4 @@ public:
         return v->strength() == 0 ? 0 : double(degreeSum) / v->strength();
     }
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNets/WeightedVertexAspect.h
+++ b/src/ComplexNets/WeightedVertexAspect.h
@@ -15,9 +15,7 @@ public:
     typedef AutonomousIterator<NeighborsWeights> WeightsIterator;
     double distance;
 
-    WeightedVertexAspect(VertexId id) : T(id)
-    {
-    }
+    WeightedVertexAspect(VertexId id) : T(id) {}
 
     void addEdge(WeightedVertexAspect<T>* other, Weight weight)
     {
@@ -55,4 +53,4 @@ public:
 private:
     NeighborsWeights weights;
 };
-}
+}  // namespace graphpp

--- a/src/ComplexNetsGui/inc/GnuplotConsole.h
+++ b/src/ComplexNetsGui/inc/GnuplotConsole.h
@@ -54,4 +54,4 @@ private:
     QGroupBox* groupBox_2;
     QLineEdit* lineEdit;
 };
-}
+}  // namespace ComplexNetsGui

--- a/src/ComplexNetsGui/inc/GraphLoadingValidationDialog.h
+++ b/src/ComplexNetsGui/inc/GraphLoadingValidationDialog.h
@@ -46,4 +46,4 @@ private:
     QRadioButton* radioButton;
     QRadioButton* radioButton_2;
 };
-}
+}  // namespace ComplexNetsGui

--- a/src/ComplexNetsGui/inc/GrapherUtils.h
+++ b/src/ComplexNetsGui/inc/GrapherUtils.h
@@ -121,4 +121,4 @@ public:
         destinationFile.close();
     }
 };
-}
+}  // namespace ComplexNetsGui

--- a/src/ComplexNetsGui/inc/LogBinningPolicy.h
+++ b/src/ComplexNetsGui/inc/LogBinningPolicy.h
@@ -184,4 +184,4 @@ private:
         return;
     }
 };
-}
+}  // namespace ComplexNetsGui

--- a/src/ComplexNetsGui/inc/mainwindow.h
+++ b/src/ComplexNetsGui/inc/mainwindow.h
@@ -127,4 +127,4 @@ private slots:
     void on_actionBoxplotNearestNeighborsDegree_triggered();
     void on_actionExportKnnBoxplot_triggered();
 };
-}
+}  // namespace ComplexNetsGui

--- a/src/ComplexNetsGui/src/GraphLoadingValidationDialog.cpp
+++ b/src/ComplexNetsGui/src/GraphLoadingValidationDialog.cpp
@@ -113,6 +113,4 @@ void GraphLoadingValidationDialog::radioButton4Changed(bool checked)
     this->mainWindow->disableActions();
 }
 
-GraphLoadingValidationDialog::~GraphLoadingValidationDialog()
-{
-}
+GraphLoadingValidationDialog::~GraphLoadingValidationDialog() {}

--- a/src/ComplexNetsGui/src/mainwindow.cpp
+++ b/src/ComplexNetsGui/src/mainwindow.cpp
@@ -1164,23 +1164,23 @@ void MainWindow::on_actionClustering_coefficient_triggered()
 
 void MainWindow::on_actionNearest_neighbors_degree_triggered()
 {
-    QString vertexId = "2";
+    if (graph.verticesCount() <= 1) {
+        ui->textBrowser->append("Number of vertexes must be greater than 1.\n");
+        return;
+    }
     QString ret;
+    Vertex::VertexId vertexId = graph.getMinVertexId();
     double neighborsDegree;
-
     std::string directedPostfix = "d";
     if (directed_out)
         directedPostfix += "p";
     if (directed_in)
         directedPostfix += "n";
-
-    if (!vertexId.isEmpty())
+    std::string key = std::to_string(vertexId);
+    if (this->digraph)
     {
-        std::string key = vertexId.toStdString();
-        if (this->digraph)
-        {
-            key += directedPostfix;
-        }
+        key += directedPostfix;
+    }
 
         if (!propertyMap.containsProperty("nearestNeighborsDegreeForVertex", key))
         {
@@ -1189,8 +1189,7 @@ void MainWindow::on_actionNearest_neighbors_degree_triggered()
             if (this->weightedgraph)
             {
                 WeightedVertex* vertex;
-                if ((vertex = weightedGraph.getVertexById(
-                         from_string<unsigned int>(vertexId.toStdString()))) != nullptr)
+                if ((vertex = weightedGraph.getVertexById(vertexId)) != nullptr)
                 {
                     auto nearestNeighborsDegree = weightedFactory->createNearestNeighborsDegree();
                     propertyMap.addProperty<double>(
@@ -1203,8 +1202,7 @@ void MainWindow::on_actionNearest_neighbors_degree_triggered()
             else if (this->digraph)
             {
                 DirectedVertex* vertex;
-                if ((vertex = directedGraph.getVertexById(
-                         from_string<unsigned int>(vertexId.toStdString()))) != nullptr)
+                if ((vertex = directedGraph.getVertexById(vertexId)) != nullptr)
                 {
                     auto nearestNeighborsDegree = directedFactory->createNearestNeighborsDegree();
                     propertyMap.addProperty<double>(
@@ -1218,8 +1216,7 @@ void MainWindow::on_actionNearest_neighbors_degree_triggered()
             else
             {
                 Vertex* vertex;
-                if ((vertex = graph.getVertexById(
-                         from_string<unsigned int>(vertexId.toStdString()))) != nullptr)
+                if ((vertex = graph.getVertexById(vertexId)) != nullptr)
                 {
                     // INearestNeighborsDegree<Graph, Vertex>* nearestNeighborsDegree =
                     // factory->createNearestNeighborsDegree();
@@ -1230,10 +1227,8 @@ void MainWindow::on_actionNearest_neighbors_degree_triggered()
                 }
             }
         }
-
-        if ((graph.getVertexById(from_string<unsigned int>(vertexId.toStdString()))) != nullptr ||
-            (this->digraph && directedGraph.getVertexById(
-                                  from_string<unsigned int>(vertexId.toStdString())) != nullptr))
+        if ((graph.getVertexById(vertexId)) != nullptr ||
+            (this->digraph && directedGraph.getVertexById(vertexId) != nullptr))
         {
             try
             {
@@ -1274,7 +1269,6 @@ void MainWindow::on_actionNearest_neighbors_degree_triggered()
             ret.append("There is no vertices with id ").append(vertexId).append(".\n");
             ui->textBrowser->append(ret);
         }
-    }
 }
 
 void MainWindow::on_actionClustering_Coefficient_vs_Degree_triggered()

--- a/src/ComplexNetsGui/src/mainwindow.cpp
+++ b/src/ComplexNetsGui/src/mainwindow.cpp
@@ -1164,12 +1164,19 @@ void MainWindow::on_actionClustering_coefficient_triggered()
 
 void MainWindow::on_actionNearest_neighbors_degree_triggered()
 {
-    if (graph.verticesCount() <= 1) {
+    if (graph.verticesCount() <= 1 && directedGraph.verticesCount() <= 1 && weightedGraph.verticesCount() <= 1) {
         ui->textBrowser->append("Number of vertexes must be greater than 1.\n");
         return;
     }
     QString ret;
-    Vertex::VertexId vertexId = graph.getMinVertexId();
+    Vertex::VertexId vertexId;
+    if(digraph) {
+        vertexId = directedGraph.getMinVertexId();
+    } else if (weightedgraph) {
+        vertexId = weightedGraph.getMinVertexId();
+    } else {
+        vertexId = graph.getMinVertexId();
+    }
     double neighborsDegree;
     std::string directedPostfix = "d";
     if (directed_out)

--- a/src/ComplexNetsGui/src/mainwindow.cpp
+++ b/src/ComplexNetsGui/src/mainwindow.cpp
@@ -1189,93 +1189,93 @@ void MainWindow::on_actionNearest_neighbors_degree_triggered()
         key += directedPostfix;
     }
 
-        if (!propertyMap.containsProperty("nearestNeighborsDegreeForVertex", key))
+    if (!propertyMap.containsProperty("nearestNeighborsDegreeForVertex", key))
+    {
+        ui->textBrowser->append(
+            "Nearest neighbors degree has not been previously computed. Computing now.");
+        if (this->weightedgraph)
         {
-            ui->textBrowser->append(
-                "Nearest neighbors degree has not been previously computed. Computing now.");
-            if (this->weightedgraph)
+            WeightedVertex* vertex;
+            if ((vertex = weightedGraph.getVertexById(vertexId)) != nullptr)
             {
-                WeightedVertex* vertex;
-                if ((vertex = weightedGraph.getVertexById(vertexId)) != nullptr)
-                {
-                    auto nearestNeighborsDegree = weightedFactory->createNearestNeighborsDegree();
-                    propertyMap.addProperty<double>(
-                        "nearestNeighborsDegreeForVertex",
-                        to_string<unsigned int>(vertex->getVertexId()),
-                        nearestNeighborsDegree->meanDegreeForVertex(vertex));
-                    delete nearestNeighborsDegree;
-                }
-            }
-            else if (this->digraph)
-            {
-                DirectedVertex* vertex;
-                if ((vertex = directedGraph.getVertexById(vertexId)) != nullptr)
-                {
-                    auto nearestNeighborsDegree = directedFactory->createNearestNeighborsDegree();
-                    propertyMap.addProperty<double>(
-                        "nearestNeighborsDegreeForVertex",
-                        to_string<unsigned int>(vertex->getVertexId()) + directedPostfix,
-                        nearestNeighborsDegree->meanDegreeForVertex(
-                            vertex, directed_out, directed_in));
-                    delete nearestNeighborsDegree;
-                }
-            }
-            else
-            {
-                Vertex* vertex;
-                if ((vertex = graph.getVertexById(vertexId)) != nullptr)
-                {
-                    // INearestNeighborsDegree<Graph, Vertex>* nearestNeighborsDegree =
-                    // factory->createNearestNeighborsDegree();
-                    // propertyMap.addProperty<double>("nearestNeighborsDegreeForVertex",
-                    // to_string<unsigned int>(vertex->getVertexId()),
-                    // nearestNeighborsDegree->meanDegreeForVertex(vertex));
-                    // delete nearestNeighborsDegree;
-                }
+                auto nearestNeighborsDegree = weightedFactory->createNearestNeighborsDegree();
+                propertyMap.addProperty<double>(
+                    "nearestNeighborsDegreeForVertex",
+                    to_string<unsigned int>(vertex->getVertexId()),
+                    nearestNeighborsDegree->meanDegreeForVertex(vertex));
+                delete nearestNeighborsDegree;
             }
         }
-        if ((graph.getVertexById(vertexId)) != nullptr ||
-            (this->digraph && directedGraph.getVertexById(vertexId) != nullptr))
+        else if (this->digraph)
         {
-            try
+            DirectedVertex* vertex;
+            if ((vertex = directedGraph.getVertexById(vertexId)) != nullptr)
             {
-                graphpp::Boxplotentry entry;
-
-                if (!propertyMap.containsProperty("KnnBPMean", to_string(0)))
-                {
-                    this->computeDegreeDistribution();
-                    entry = this->computeTotalBpEntriesKnn();
-                    propertyMap.addProperty<double>("KnnBPMean", to_string(0), entry.mean);
-                    propertyMap.addProperty<double>("KnnBPMin", to_string(0), entry.min);
-                    propertyMap.addProperty<double>("KnnBPQ1", to_string(0), entry.Q1);
-                    propertyMap.addProperty<double>("KnnBPQ2", to_string(0), entry.Q2);
-                    propertyMap.addProperty<double>("KnnBPQ3", to_string(0), entry.Q3);
-                    propertyMap.addProperty<double>("KnnBPMax", to_string(0), entry.max);
-                }
-                else
-                {
-                    ret.append("Data already calculated. \n");
-                    entry.mean = propertyMap.getProperty<double>("KnnBPMean", to_string(0));
-                    entry.min = propertyMap.getProperty<double>("KnnBPMin", to_string(0));
-                    entry.Q1 = propertyMap.getProperty<double>("KnnBPQ1", to_string(0));
-                    entry.Q2 = propertyMap.getProperty<double>("KnnBPQ2", to_string(0));
-                    entry.Q3 = propertyMap.getProperty<double>("KnnBPQ3", to_string(0));
-                    entry.max = propertyMap.getProperty<double>("KnnBPMax", to_string(0));
-                }
-
-                ui->textBrowser->append(entry.str().c_str());
-            }
-            catch (const BadElementName& ex)
-            {
-                ret.append("There is no vertices with id ").append(vertexId).append(".\n");
-                ui->textBrowser->append(ret);
+                auto nearestNeighborsDegree = directedFactory->createNearestNeighborsDegree();
+                propertyMap.addProperty<double>(
+                    "nearestNeighborsDegreeForVertex",
+                    to_string<unsigned int>(vertex->getVertexId()) + directedPostfix,
+                    nearestNeighborsDegree->meanDegreeForVertex(
+                        vertex, directed_out, directed_in));
+                delete nearestNeighborsDegree;
             }
         }
         else
         {
+            Vertex* vertex;
+            if ((vertex = graph.getVertexById(vertexId)) != nullptr)
+            {
+                // INearestNeighborsDegree<Graph, Vertex>* nearestNeighborsDegree =
+                // factory->createNearestNeighborsDegree();
+                // propertyMap.addProperty<double>("nearestNeighborsDegreeForVertex",
+                // to_string<unsigned int>(vertex->getVertexId()),
+                // nearestNeighborsDegree->meanDegreeForVertex(vertex));
+                // delete nearestNeighborsDegree;
+            }
+        }
+    }
+    if ((graph.getVertexById(vertexId)) != nullptr ||
+        (this->digraph && directedGraph.getVertexById(vertexId) != nullptr))
+    {
+        try
+        {
+            graphpp::Boxplotentry entry;
+
+            if (!propertyMap.containsProperty("KnnBPMean", to_string(0)))
+            {
+                this->computeDegreeDistribution();
+                entry = this->computeTotalBpEntriesKnn();
+                propertyMap.addProperty<double>("KnnBPMean", to_string(0), entry.mean);
+                propertyMap.addProperty<double>("KnnBPMin", to_string(0), entry.min);
+                propertyMap.addProperty<double>("KnnBPQ1", to_string(0), entry.Q1);
+                propertyMap.addProperty<double>("KnnBPQ2", to_string(0), entry.Q2);
+                propertyMap.addProperty<double>("KnnBPQ3", to_string(0), entry.Q3);
+                propertyMap.addProperty<double>("KnnBPMax", to_string(0), entry.max);
+            }
+            else
+            {
+                ret.append("Data already calculated. \n");
+                entry.mean = propertyMap.getProperty<double>("KnnBPMean", to_string(0));
+                entry.min = propertyMap.getProperty<double>("KnnBPMin", to_string(0));
+                entry.Q1 = propertyMap.getProperty<double>("KnnBPQ1", to_string(0));
+                entry.Q2 = propertyMap.getProperty<double>("KnnBPQ2", to_string(0));
+                entry.Q3 = propertyMap.getProperty<double>("KnnBPQ3", to_string(0));
+                entry.max = propertyMap.getProperty<double>("KnnBPMax", to_string(0));
+            }
+
+            ui->textBrowser->append(entry.str().c_str());
+        }
+        catch (const BadElementName& ex)
+        {
             ret.append("There is no vertices with id ").append(vertexId).append(".\n");
             ui->textBrowser->append(ret);
         }
+    }
+    else
+    {
+        ret.append("There is no vertices with id ").append(vertexId).append(".\n");
+        ui->textBrowser->append(ret);
+    }
 }
 
 void MainWindow::on_actionClustering_Coefficient_vs_Degree_triggered()

--- a/src/ComplexNetsGui/src/mainwindow.cpp
+++ b/src/ComplexNetsGui/src/mainwindow.cpp
@@ -538,10 +538,12 @@ void MainWindow::on_actionMaxClique_generic_triggered(bool exact)
         std::string key = exact ? "maxCliqueExact" : "maxCliqueAprox";
         int maxCliqueSize = propertyMap.getProperty<int>(key, "size");
         std::list<int> list = propertyMap.getProperty<std::list<int>>(key, "list");
-        ui->textBrowser->append(exact ? "Exact Max clique" : "Aprox Max clique"
-                                "\nReference: José Ignacio Alvarez-Hamelin. "
-                                "Is it possible to find the maximum clique in general graphs? "
-                                "arXiv e-print, abs/1110.5355, Oct 2011.");
+        ui->textBrowser->append(
+            exact ? "Exact Max clique"
+                  : "Aprox Max clique"
+                    "\nReference: José Ignacio Alvarez-Hamelin. "
+                    "Is it possible to find the maximum clique in general graphs? "
+                    "arXiv e-print, abs/1110.5355, Oct 2011.");
         ret.append("Size is: ").append(to_string<int>(maxCliqueSize).c_str()).append(".\n");
         ret.append("Clique is: ");
         for (const auto& elem : list)
@@ -1164,17 +1166,24 @@ void MainWindow::on_actionClustering_coefficient_triggered()
 
 void MainWindow::on_actionNearest_neighbors_degree_triggered()
 {
-    if (graph.verticesCount() <= 1 && directedGraph.verticesCount() <= 1 && weightedGraph.verticesCount() <= 1) {
+    if (graph.verticesCount() <= 1 && directedGraph.verticesCount() <= 1 &&
+        weightedGraph.verticesCount() <= 1)
+    {
         ui->textBrowser->append("Number of vertexes must be greater than 1.\n");
         return;
     }
     QString ret;
     Vertex::VertexId vertexId;
-    if(digraph) {
+    if (digraph)
+    {
         vertexId = directedGraph.getMinVertexId();
-    } else if (weightedgraph) {
+    }
+    else if (weightedgraph)
+    {
         vertexId = weightedGraph.getMinVertexId();
-    } else {
+    }
+    else
+    {
         vertexId = graph.getMinVertexId();
     }
     double neighborsDegree;
@@ -1215,8 +1224,7 @@ void MainWindow::on_actionNearest_neighbors_degree_triggered()
                 propertyMap.addProperty<double>(
                     "nearestNeighborsDegreeForVertex",
                     to_string<unsigned int>(vertex->getVertexId()) + directedPostfix,
-                    nearestNeighborsDegree->meanDegreeForVertex(
-                        vertex, directed_out, directed_in));
+                    nearestNeighborsDegree->meanDegreeForVertex(vertex, directed_out, directed_in));
                 delete nearestNeighborsDegree;
             }
         }


### PR DESCRIPTION
## Problem
For the `Nearest Neighbor Degree` calculation it was needed for the graph to have a node with id equal to **2** unnecessarily. This was used as a check for the graph size. As a consequence, any graph which didn't fulfill that restriction would not return the result of the function.
## Solution
This is addressed by obtaining the minimum vertex id from the graph. A check for the graph size is added, so that no calculation is done if the graph has only got 1 vertex.
## Known issues
This solution solves the problem for undirected / unweighted graphs. However, an issue which was still in the previous version, for directed and weighted graphs, is still making the function to crash, but it is independent of the problem solved here.