### PR TITLE
Fix dependency on id number in clustering coefficient calculation

### DIFF
--- a/src/ComplexNets/AdjacencyListGraph.h
+++ b/src/ComplexNets/AdjacencyListGraph.h
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <iostream>
 #include <memory>
+#include <climits>
 #include "GraphExceptions.h"
 #include "mili/mili.h"
 
@@ -185,6 +186,26 @@ public:
     Vertex* getVertexById(VertexId id) const
     {
         return VertexFinder<Vertex, VertexContainer>::find(id, vertices);
+    }
+
+    /**
+     * Method: getMinVertexId
+     * ----------------------
+     * Description: obtains the minimum vertex id in the graph.
+     * @return the minimum vertex id in the graph
+     */
+    VertexId getMinVertexId() const
+    {
+        VertexId currMin = UINT_MAX;
+        VerticesConstIterator it = verticesConstIterator();
+        while(!it.end()) {
+            VertexId currId = (*it) -> getVertexId();
+            if(currId < currMin) {
+                currMin = currId;
+            }
+            it++;
+        }
+        return currMin;
     }
 
     /**

--- a/src/ComplexNets/WeightedGraphAspect.h
+++ b/src/ComplexNets/WeightedGraphAspect.h
@@ -18,8 +18,6 @@ public:
         s->addEdge(d, weight);
         if (!this->isDigraph())
             d->addEdge(s, weight);
-        // s->addEdge(d, weight);
-        // d->addEdge(s, weight);
     }
 };
 }

--- a/src/ComplexNetsGui/src/mainwindow.cpp
+++ b/src/ComplexNetsGui/src/mainwindow.cpp
@@ -1164,23 +1164,23 @@ void MainWindow::on_actionClustering_coefficient_triggered()
 
 void MainWindow::on_actionNearest_neighbors_degree_triggered()
 {
-    QString vertexId = "2";
+    if (graph.verticesCount() <= 1) {
+        ui->textBrowser->append("Number of vertexes must be greater than 1.\n");
+        return;
+    }
     QString ret;
+    Vertex::VertexId vertexId = graph.getMinVertexId();
     double neighborsDegree;
-
     std::string directedPostfix = "d";
     if (directed_out)
         directedPostfix += "p";
     if (directed_in)
         directedPostfix += "n";
-
-    if (!vertexId.isEmpty())
+    std::string key = std::to_string(vertexId);
+    if (this->digraph)
     {
-        std::string key = vertexId.toStdString();
-        if (this->digraph)
-        {
-            key += directedPostfix;
-        }
+        key += directedPostfix;
+    }
 
         if (!propertyMap.containsProperty("nearestNeighborsDegreeForVertex", key))
         {
@@ -1189,8 +1189,7 @@ void MainWindow::on_actionNearest_neighbors_degree_triggered()
             if (this->weightedgraph)
             {
                 WeightedVertex* vertex;
-                if ((vertex = weightedGraph.getVertexById(
-                         from_string<unsigned int>(vertexId.toStdString()))) != nullptr)
+                if ((vertex = weightedGraph.getVertexById(vertexId)) != nullptr)
                 {
                     auto nearestNeighborsDegree = weightedFactory->createNearestNeighborsDegree();
                     propertyMap.addProperty<double>(
@@ -1203,8 +1202,7 @@ void MainWindow::on_actionNearest_neighbors_degree_triggered()
             else if (this->digraph)
             {
                 DirectedVertex* vertex;
-                if ((vertex = directedGraph.getVertexById(
-                         from_string<unsigned int>(vertexId.toStdString()))) != nullptr)
+                if ((vertex = directedGraph.getVertexById(vertexId)) != nullptr)
                 {
                     auto nearestNeighborsDegree = directedFactory->createNearestNeighborsDegree();
                     propertyMap.addProperty<double>(
@@ -1218,8 +1216,7 @@ void MainWindow::on_actionNearest_neighbors_degree_triggered()
             else
             {
                 Vertex* vertex;
-                if ((vertex = graph.getVertexById(
-                         from_string<unsigned int>(vertexId.toStdString()))) != nullptr)
+                if ((vertex = graph.getVertexById(vertexId)) != nullptr)
                 {
                     // INearestNeighborsDegree<Graph, Vertex>* nearestNeighborsDegree =
                     // factory->createNearestNeighborsDegree();
@@ -1230,10 +1227,8 @@ void MainWindow::on_actionNearest_neighbors_degree_triggered()
                 }
             }
         }
-
-        if ((graph.getVertexById(from_string<unsigned int>(vertexId.toStdString()))) != nullptr ||
-            (this->digraph && directedGraph.getVertexById(
-                                  from_string<unsigned int>(vertexId.toStdString())) != nullptr))
+        if ((graph.getVertexById(vertexId)) != nullptr ||
+            (this->digraph && directedGraph.getVertexById(vertexId) != nullptr))
         {
             try
             {
@@ -1274,7 +1269,6 @@ void MainWindow::on_actionNearest_neighbors_degree_triggered()
             ret.append("There is no vertices with id ").append(vertexId).append(".\n");
             ui->textBrowser->append(ret);
         }
-    }
 }
 
 void MainWindow::on_actionClustering_Coefficient_vs_Degree_triggered()

--- a/src/ComplexNetsGui/src/mainwindow.cpp
+++ b/src/ComplexNetsGui/src/mainwindow.cpp
@@ -1164,12 +1164,19 @@ void MainWindow::on_actionClustering_coefficient_triggered()
 
 void MainWindow::on_actionNearest_neighbors_degree_triggered()
 {
-    if (graph.verticesCount() <= 1) {
+    if (graph.verticesCount() <= 1 && directedGraph.verticesCount() <= 1 && weightedGraph.verticesCount() <= 1) {
         ui->textBrowser->append("Number of vertexes must be greater than 1.\n");
         return;
     }
     QString ret;
-    Vertex::VertexId vertexId = graph.getMinVertexId();
+    Vertex::VertexId vertexId;
+    if(digraph) {
+        vertexId = directedGraph.getMinVertexId();
+    } else if (weightedgraph) {
+        vertexId = weightedGraph.getMinVertexId();
+    } else {
+        vertexId = graph.getMinVertexId();
+    }
     double neighborsDegree;
     std::string directedPostfix = "d";
     if (directed_out)

--- a/src/ComplexNetsGui/src/mainwindow.cpp
+++ b/src/ComplexNetsGui/src/mainwindow.cpp
@@ -1036,7 +1036,18 @@ void MainWindow::on_actionDegree_distribution_plotting_triggered()
 
 void MainWindow::on_actionClustering_coefficient_triggered()
 {
-    QString vertexId = "2";
+    if (graph.verticesCount() <= 1 && directedGraph.verticesCount() <= 1 && weightedGraph.verticesCount() <= 1) {
+        ui->textBrowser->append("Number of vertexes must be greater than 1.\n");
+        return;
+    }
+    Vertex::VertexId vertexId;
+    if(digraph) {
+        vertexId = directedGraph.getMinVertexId();
+    } else if (weightedgraph) {
+        vertexId = weightedGraph.getMinVertexId();
+    } else {
+        vertexId = graph.getMinVertexId();
+    }
     QString ret;
 
     std::string directedPostfix = "d";
@@ -1044,121 +1055,113 @@ void MainWindow::on_actionClustering_coefficient_triggered()
         directedPostfix += "p";
     if (directed_in)
         directedPostfix += "n";
-
-    if (!vertexId.isEmpty())
+    std::string key = std::to_string(vertexId);
+    if (this->digraph)
     {
-        std::string key = vertexId.toStdString();
-        if (this->digraph)
-        {
-            key += directedPostfix;
-        }
+        key += directedPostfix;
+    }
 
-        if (!propertyMap.containsProperty("clusteringCoeficientForVertex", key))
+    if (!propertyMap.containsProperty("clusteringCoeficientForVertex", key))
+    {
+        ui->textBrowser->append("Clustering coefficient has not been previously computed.");
+        if (this->weightedgraph)
         {
-            ui->textBrowser->append("Clustering coefficient has not been previously computed.");
-            if (this->weightedgraph)
+            WeightedVertex* vertex;
+            if ((vertex = weightedGraph.getVertexById(vertexId)) != nullptr)
             {
-                WeightedVertex* vertex;
-                if ((vertex = weightedGraph.getVertexById(
-                         from_string<unsigned int>(vertexId.toStdString()))) != nullptr)
-                {
-                    auto clusteringCoefficient = weightedFactory->createClusteringCoefficient();
-                    propertyMap.addProperty<double>(
+                auto clusteringCoefficient = weightedFactory->createClusteringCoefficient();
+                propertyMap.addProperty<double>(
                         "clusteringCoeficientForVertex",
                         to_string<unsigned int>(vertex->getVertexId()),
                         clusteringCoefficient->vertexClusteringCoefficient(vertex));
-                    delete clusteringCoefficient;
-                }
+                delete clusteringCoefficient;
             }
-            else if (this->digraph)
+        }
+        else if (this->digraph)
+        {
+            DirectedVertex* vertex;
+            if ((vertex = directedGraph.getVertexById(vertexId)) != nullptr)
             {
-                DirectedVertex* vertex;
-                if ((vertex = directedGraph.getVertexById(
-                         from_string<unsigned int>(vertexId.toStdString()))) != nullptr)
-                {
-                    auto clusteringCoefficient = directedFactory->createClusteringCoefficient();
-                    propertyMap.addProperty<double>(
+                auto clusteringCoefficient = directedFactory->createClusteringCoefficient();
+                propertyMap.addProperty<double>(
                         "clusteringCoeficientForVertex",
                         to_string<unsigned int>(vertex->getVertexId()) + directedPostfix,
                         clusteringCoefficient->vertexClusteringCoefficient(
-                            vertex, directed_out, directed_in));
-                    delete clusteringCoefficient;
-                }
-            }
-            else
-            {
-                Vertex* vertex;
-                if ((vertex = graph.getVertexById(
-                         from_string<unsigned int>(vertexId.toStdString()))) != nullptr)
-                {
-                    // IClusteringCoefficient<Graph, Vertex>* clusteringCoefficient =
-                    // factory->createClusteringCoefficient();
-                    // propertyMap.addProperty<double>("clusteringCoeficientForVertex",
-                    // to_string<unsigned int>(vertex->getVertexId()),
-                    // clusteringCoefficient->vertexClusteringCoefficient(vertex));
-                    // delete clusteringCoefficient;
-                }
-            }
-        }
-
-        if ((graph.getVertexById(from_string<unsigned int>(vertexId.toStdString()))) != nullptr ||
-            (this->digraph && directedGraph.getVertexById(
-                                  from_string<unsigned int>(vertexId.toStdString())) != nullptr))
-        {
-            try
-            {
-                // std::string key = vertexId.toStdString();
-                // if (this->digraph) {
-                //    key += directedPostfix;
-                //}
-                graphpp::Boxplotentry entry;
-                if (!propertyMap.containsProperty("ClusteringCoefficientBPMean", to_string(0)))
-                {
-                    this->computeDegreeDistribution();
-                    entry = this->computeTotalBpEntries();
-                    propertyMap.addProperty<double>(
-                        "ClusteringCoefficientBPMean", to_string(0), entry.mean);
-                    propertyMap.addProperty<double>(
-                        "ClusteringCoefficientBPMin", to_string(0), entry.min);
-                    propertyMap.addProperty<double>(
-                        "ClusteringCoefficientBPQ1", to_string(0), entry.Q1);
-                    propertyMap.addProperty<double>(
-                        "ClusteringCoefficientBPQ2", to_string(0), entry.Q2);
-                    propertyMap.addProperty<double>(
-                        "ClusteringCoefficientBPQ3", to_string(0), entry.Q3);
-                    propertyMap.addProperty<double>(
-                        "ClusteringCoefficientBPMax", to_string(0), entry.max);
-                }
-                else
-                {
-                    ret.append("Data already calculated. \n");
-                    entry.mean = propertyMap.getProperty<double>(
-                        "ClusteringCoefficientBPMean", to_string(0));
-                    entry.min =
-                        propertyMap.getProperty<double>("ClusteringCoefficientBPMin", to_string(0));
-                    entry.Q1 =
-                        propertyMap.getProperty<double>("ClusteringCoefficientBPQ1", to_string(0));
-                    entry.Q2 =
-                        propertyMap.getProperty<double>("ClusteringCoefficientBPQ2", to_string(0));
-                    entry.Q3 =
-                        propertyMap.getProperty<double>("ClusteringCoefficientBPQ3", to_string(0));
-                    entry.max =
-                        propertyMap.getProperty<double>("ClusteringCoefficientBPMax", to_string(0));
-                }
-
-                ui->textBrowser->append(entry.str().c_str());
-            }
-            catch (const BadElementName& ex)
-            {
-                ret.append("There is no vertices with id ").append(vertexId).append(".\n");
-                ui->textBrowser->append(ret);
+                                vertex, directed_out, directed_in));
+                delete clusteringCoefficient;
             }
         }
         else
         {
+            Vertex* vertex;
+            if ((vertex = graph.getVertexById(vertexId)) != nullptr)
+            {
+                // IClusteringCoefficient<Graph, Vertex>* clusteringCoefficient =
+                // factory->createClusteringCoefficient();
+                // propertyMap.addProperty<double>("clusteringCoeficientForVertex",
+                // to_string<unsigned int>(vertex->getVertexId()),
+                // clusteringCoefficient->vertexClusteringCoefficient(vertex));
+                // delete clusteringCoefficient;
+            }
+        }
+    }
+
+    if ((graph.getVertexById(vertexId)) != nullptr ||
+        (this->digraph && directedGraph.getVertexById(vertexId) != nullptr))
+    {
+        try
+        {
+            // std::string key = vertexId.toStdString();
+            // if (this->digraph) {
+            //    key += directedPostfix;
+            //}
+            graphpp::Boxplotentry entry;
+            if (!propertyMap.containsProperty("ClusteringCoefficientBPMean", to_string(0)))
+            {
+                this->computeDegreeDistribution();
+                entry = this->computeTotalBpEntries();
+                propertyMap.addProperty<double>(
+                        "ClusteringCoefficientBPMean", to_string(0), entry.mean);
+                propertyMap.addProperty<double>(
+                        "ClusteringCoefficientBPMin", to_string(0), entry.min);
+                propertyMap.addProperty<double>(
+                        "ClusteringCoefficientBPQ1", to_string(0), entry.Q1);
+                propertyMap.addProperty<double>(
+                        "ClusteringCoefficientBPQ2", to_string(0), entry.Q2);
+                propertyMap.addProperty<double>(
+                        "ClusteringCoefficientBPQ3", to_string(0), entry.Q3);
+                propertyMap.addProperty<double>(
+                        "ClusteringCoefficientBPMax", to_string(0), entry.max);
+            }
+            else
+            {
+                ret.append("Data already calculated. \n");
+                entry.mean = propertyMap.getProperty<double>(
+                        "ClusteringCoefficientBPMean", to_string(0));
+                entry.min =
+                        propertyMap.getProperty<double>("ClusteringCoefficientBPMin", to_string(0));
+                entry.Q1 =
+                        propertyMap.getProperty<double>("ClusteringCoefficientBPQ1", to_string(0));
+                entry.Q2 =
+                        propertyMap.getProperty<double>("ClusteringCoefficientBPQ2", to_string(0));
+                entry.Q3 =
+                        propertyMap.getProperty<double>("ClusteringCoefficientBPQ3", to_string(0));
+                entry.max =
+                        propertyMap.getProperty<double>("ClusteringCoefficientBPMax", to_string(0));
+            }
+
+            ui->textBrowser->append(entry.str().c_str());
+        }
+        catch (const BadElementName& ex)
+        {
             ret.append("There is no vertices with id ").append(vertexId).append(".\n");
             ui->textBrowser->append(ret);
         }
+    }
+    else
+    {
+        ret.append("There is no vertices with id ").append(vertexId).append(".\n");
+        ui->textBrowser->append(ret);
     }
 }
 

--- a/src/ComplexNetsGui/src/mainwindow.cpp
+++ b/src/ComplexNetsGui/src/mainwindow.cpp
@@ -1189,93 +1189,93 @@ void MainWindow::on_actionNearest_neighbors_degree_triggered()
         key += directedPostfix;
     }
 
-        if (!propertyMap.containsProperty("nearestNeighborsDegreeForVertex", key))
+    if (!propertyMap.containsProperty("nearestNeighborsDegreeForVertex", key))
+    {
+        ui->textBrowser->append(
+            "Nearest neighbors degree has not been previously computed. Computing now.");
+        if (this->weightedgraph)
         {
-            ui->textBrowser->append(
-                "Nearest neighbors degree has not been previously computed. Computing now.");
-            if (this->weightedgraph)
+            WeightedVertex* vertex;
+            if ((vertex = weightedGraph.getVertexById(vertexId)) != nullptr)
             {
-                WeightedVertex* vertex;
-                if ((vertex = weightedGraph.getVertexById(vertexId)) != nullptr)
-                {
-                    auto nearestNeighborsDegree = weightedFactory->createNearestNeighborsDegree();
-                    propertyMap.addProperty<double>(
-                        "nearestNeighborsDegreeForVertex",
-                        to_string<unsigned int>(vertex->getVertexId()),
-                        nearestNeighborsDegree->meanDegreeForVertex(vertex));
-                    delete nearestNeighborsDegree;
-                }
-            }
-            else if (this->digraph)
-            {
-                DirectedVertex* vertex;
-                if ((vertex = directedGraph.getVertexById(vertexId)) != nullptr)
-                {
-                    auto nearestNeighborsDegree = directedFactory->createNearestNeighborsDegree();
-                    propertyMap.addProperty<double>(
-                        "nearestNeighborsDegreeForVertex",
-                        to_string<unsigned int>(vertex->getVertexId()) + directedPostfix,
-                        nearestNeighborsDegree->meanDegreeForVertex(
-                            vertex, directed_out, directed_in));
-                    delete nearestNeighborsDegree;
-                }
-            }
-            else
-            {
-                Vertex* vertex;
-                if ((vertex = graph.getVertexById(vertexId)) != nullptr)
-                {
-                    // INearestNeighborsDegree<Graph, Vertex>* nearestNeighborsDegree =
-                    // factory->createNearestNeighborsDegree();
-                    // propertyMap.addProperty<double>("nearestNeighborsDegreeForVertex",
-                    // to_string<unsigned int>(vertex->getVertexId()),
-                    // nearestNeighborsDegree->meanDegreeForVertex(vertex));
-                    // delete nearestNeighborsDegree;
-                }
+                auto nearestNeighborsDegree = weightedFactory->createNearestNeighborsDegree();
+                propertyMap.addProperty<double>(
+                    "nearestNeighborsDegreeForVertex",
+                    to_string<unsigned int>(vertex->getVertexId()),
+                    nearestNeighborsDegree->meanDegreeForVertex(vertex));
+                delete nearestNeighborsDegree;
             }
         }
-        if ((graph.getVertexById(vertexId)) != nullptr ||
-            (this->digraph && directedGraph.getVertexById(vertexId) != nullptr))
+        else if (this->digraph)
         {
-            try
+            DirectedVertex* vertex;
+            if ((vertex = directedGraph.getVertexById(vertexId)) != nullptr)
             {
-                graphpp::Boxplotentry entry;
-
-                if (!propertyMap.containsProperty("KnnBPMean", to_string(0)))
-                {
-                    this->computeDegreeDistribution();
-                    entry = this->computeTotalBpEntriesKnn();
-                    propertyMap.addProperty<double>("KnnBPMean", to_string(0), entry.mean);
-                    propertyMap.addProperty<double>("KnnBPMin", to_string(0), entry.min);
-                    propertyMap.addProperty<double>("KnnBPQ1", to_string(0), entry.Q1);
-                    propertyMap.addProperty<double>("KnnBPQ2", to_string(0), entry.Q2);
-                    propertyMap.addProperty<double>("KnnBPQ3", to_string(0), entry.Q3);
-                    propertyMap.addProperty<double>("KnnBPMax", to_string(0), entry.max);
-                }
-                else
-                {
-                    ret.append("Data already calculated. \n");
-                    entry.mean = propertyMap.getProperty<double>("KnnBPMean", to_string(0));
-                    entry.min = propertyMap.getProperty<double>("KnnBPMin", to_string(0));
-                    entry.Q1 = propertyMap.getProperty<double>("KnnBPQ1", to_string(0));
-                    entry.Q2 = propertyMap.getProperty<double>("KnnBPQ2", to_string(0));
-                    entry.Q3 = propertyMap.getProperty<double>("KnnBPQ3", to_string(0));
-                    entry.max = propertyMap.getProperty<double>("KnnBPMax", to_string(0));
-                }
-
-                ui->textBrowser->append(entry.str().c_str());
-            }
-            catch (const BadElementName& ex)
-            {
-                ret.append("There is no vertices with id ").append(vertexId).append(".\n");
-                ui->textBrowser->append(ret);
+                auto nearestNeighborsDegree = directedFactory->createNearestNeighborsDegree();
+                propertyMap.addProperty<double>(
+                    "nearestNeighborsDegreeForVertex",
+                    to_string<unsigned int>(vertex->getVertexId()) + directedPostfix,
+                    nearestNeighborsDegree->meanDegreeForVertex(
+                        vertex, directed_out, directed_in));
+                delete nearestNeighborsDegree;
             }
         }
         else
         {
+            Vertex* vertex;
+            if ((vertex = graph.getVertexById(vertexId)) != nullptr)
+            {
+                // INearestNeighborsDegree<Graph, Vertex>* nearestNeighborsDegree =
+                // factory->createNearestNeighborsDegree();
+                // propertyMap.addProperty<double>("nearestNeighborsDegreeForVertex",
+                // to_string<unsigned int>(vertex->getVertexId()),
+                // nearestNeighborsDegree->meanDegreeForVertex(vertex));
+                // delete nearestNeighborsDegree;
+            }
+        }
+    }
+    if ((graph.getVertexById(vertexId)) != nullptr ||
+        (this->digraph && directedGraph.getVertexById(vertexId) != nullptr))
+    {
+        try
+        {
+            graphpp::Boxplotentry entry;
+
+            if (!propertyMap.containsProperty("KnnBPMean", to_string(0)))
+            {
+                this->computeDegreeDistribution();
+                entry = this->computeTotalBpEntriesKnn();
+                propertyMap.addProperty<double>("KnnBPMean", to_string(0), entry.mean);
+                propertyMap.addProperty<double>("KnnBPMin", to_string(0), entry.min);
+                propertyMap.addProperty<double>("KnnBPQ1", to_string(0), entry.Q1);
+                propertyMap.addProperty<double>("KnnBPQ2", to_string(0), entry.Q2);
+                propertyMap.addProperty<double>("KnnBPQ3", to_string(0), entry.Q3);
+                propertyMap.addProperty<double>("KnnBPMax", to_string(0), entry.max);
+            }
+            else
+            {
+                ret.append("Data already calculated. \n");
+                entry.mean = propertyMap.getProperty<double>("KnnBPMean", to_string(0));
+                entry.min = propertyMap.getProperty<double>("KnnBPMin", to_string(0));
+                entry.Q1 = propertyMap.getProperty<double>("KnnBPQ1", to_string(0));
+                entry.Q2 = propertyMap.getProperty<double>("KnnBPQ2", to_string(0));
+                entry.Q3 = propertyMap.getProperty<double>("KnnBPQ3", to_string(0));
+                entry.max = propertyMap.getProperty<double>("KnnBPMax", to_string(0));
+            }
+
+            ui->textBrowser->append(entry.str().c_str());
+        }
+        catch (const BadElementName& ex)
+        {
             ret.append("There is no vertices with id ").append(vertexId).append(".\n");
             ui->textBrowser->append(ret);
         }
+    }
+    else
+    {
+        ret.append("There is no vertices with id ").append(vertexId).append(".\n");
+        ui->textBrowser->append(ret);
+    }
 }
 
 void MainWindow::on_actionClustering_Coefficient_vs_Degree_triggered()


### PR DESCRIPTION
## Important
These changes depend on Pull Request #27, to see only the changes done here, merge that Pull Request first.

## Problem
For the `Clustering Coefficient` calculation it was needed for the graph to have a node with id equal to **2** unnecessarily. This was used as a check for the graph size. As a consequence, any graph which didn't fulfill that restriction would not return the result of the function.
## Solution
This is addressed by obtaining the minimum vertex id from the graph. A check for the graph size is added, so that no calculation is done if the graph has only got 1 vertex.