### PR TITLE
Several UI and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,4 @@ The first version was released in 2012.
 | Juan Pablo Dantur                | 2-2016          |
 | Federico Bond                    | 1-2017          |
 | Matías Comercio                  | 1-2018          |
+| Gonzalo Ibars Ingman             | 1-2018          |

--- a/src/gui/inc/mainwindow.h
+++ b/src/gui/inc/mainwindow.h
@@ -89,8 +89,8 @@ private:
     bool closeCurrentGraph();
     std::string getSavePath() const;
     QString inputId(std::string const& label);
-    int intInputId(std::string const& label);
-    double doubleInputId(std::string const& label);
+    int intInputId(std::string const& label, int defaultNum);
+    double doubleInputId(std::string const& label, double defaultNum);
 
 private slots:
     void on_actionExportPowerLawDegreeDistribution_triggered();

--- a/src/gui/inc/mainwindow.h
+++ b/src/gui/inc/mainwindow.h
@@ -89,6 +89,8 @@ private:
     bool closeCurrentGraph();
     std::string getSavePath() const;
     QString inputId(std::string const& label);
+    int intInputId(std::string const& label);
+    double doubleInputId(std::string const& label);
 
 private slots:
     void on_actionExportPowerLawDegreeDistribution_triggered();

--- a/src/gui/src/mainwindow.cpp
+++ b/src/gui/src/mainwindow.cpp
@@ -76,9 +76,25 @@ void MainWindow::on_actionOpen_triggered()
 
     if (this->graphLoaded)
     {
-        ui->textBrowser->append(
-            "Action canceled: Only one network can be loaded at any given time.\n");
-        return;
+        QMessageBox msg(
+                QMessageBox::Question, "Close current network",
+                "Are you sure you want to close the current network?",
+                QMessageBox::Ok | QMessageBox::Cancel, this);
+        if (msg.exec() == QMessageBox::Ok)
+        {
+            graph = Graph();
+            weightedGraph = WeightedGraph();
+            this->deleteGraphFactory();
+            propertyMap.clear();
+            this->onNetworkUnload();
+            ui->textBrowser->append("Done.\n");
+        }
+        else {
+            ui->textBrowser->append("Action canceled by user.\n");
+            ui->textBrowser->append(
+                    "Action canceled: Only one network can be loaded at any given time.\n");
+            return;
+        }
     }
 
     // If no network is loaded user may procede to load a new network.

--- a/src/gui/src/mainwindow.cpp
+++ b/src/gui/src/mainwindow.cpp
@@ -201,8 +201,8 @@ void MainWindow::on_actionExportPowerLawDegreeDistribution_triggered()
         return;
     }
 
-    int alfa = intInputId("alfa:");
-    int n = intInputId("nodes:");
+    int alfa = intInputId("alfa:", 0);
+    int n = intInputId("nodes:", 0);
 
     double dmax = pow(n, 1.0 / alfa);
     std::cout << "dmax: " << dmax << "\n";
@@ -425,7 +425,7 @@ QString MainWindow::inputId(std::string const& label)
     return ret;
 }
 
-int MainWindow::intInputId(std::string const& label)
+int MainWindow::intInputId(std::string const& label, int defaultNum)
 {
     QString ret;
     QInputDialog inputVertexIdDialog(this);
@@ -433,25 +433,25 @@ int MainWindow::intInputId(std::string const& label)
     inputVertexIdDialog.setIntMinimum(0);
     inputVertexIdDialog.setIntMaximum(INT_MAX);
     inputVertexIdDialog.setLabelText(label.c_str());
-    inputVertexIdDialog.setCancelButtonText("Default = 0");
+    inputVertexIdDialog.setCancelButtonText("Default = " + QString::number(defaultNum));
     if (inputVertexIdDialog.exec())
         return inputVertexIdDialog.intValue();
     else
-        return 0;
+        return defaultNum;
 }
 
-double MainWindow::doubleInputId(std::string const& label)
+double MainWindow::doubleInputId(std::string const& label, double defaultNum)
 {
     QString ret;
     QInputDialog inputVertexIdDialog(this);
     inputVertexIdDialog.setInputMode(QInputDialog::DoubleInput);
     inputVertexIdDialog.setDoubleDecimals(8);
     inputVertexIdDialog.setLabelText(label.c_str());
-    inputVertexIdDialog.setCancelButtonText("Default = 0.0");
+    inputVertexIdDialog.setCancelButtonText("Default = " + QString::number(defaultNum));
     if (inputVertexIdDialog.exec())
         return inputVertexIdDialog.doubleValue();
     else
-        return 0.0;
+        return defaultNum;
 }
 
 void MainWindow::on_actionExportMaxCliqueExact_distribution_triggered()
@@ -512,7 +512,7 @@ void MainWindow::on_action_maxClique_plotting_generic_triggered(bool exact)
     if (LogBinningDialog() == QMessageBox::Yes)
     {
         logBin = true;
-        bins = intInputId("bins:");
+        bins = intInputId("bins:", 25);
     }
 
     bool ret = this->console->plotPropertySet(
@@ -733,7 +733,7 @@ void MainWindow::computeMaxClique(bool exact)
         int timeout = 0;
         if (exact)
         {
-            timeout = intInputId("Time out (seconds):");
+            timeout = intInputId("Time out (seconds):", 0);
         }
         IMaxClique<Graph, Vertex>* maxClique =
             exact ? (IMaxClique<Graph, Vertex>*)factory->createExactMaxClique(graph, timeout)
@@ -1001,7 +1001,7 @@ void MainWindow::on_actionDegree_distribution_plotting_triggered()
     if (LogBinningDialog() == QMessageBox::Yes)
     {
         logBin = true;
-        bins = intInputId("bins:");
+        bins = intInputId("bins:", 25);
     }
     if (!this->digraph)
     {
@@ -1827,10 +1827,9 @@ void MainWindow::on_actionNewErdosRenyi_triggered()
     if (!closeCurrentGraph())
         return;
 
-    int n = intInputId("n:");
-    double p = doubleInputId("p:");
+    int n = intInputId("n:", 1000);
+    double p = doubleInputId("p:", 0.01);
     QString ret;
-
 
     try
     {
@@ -1866,9 +1865,9 @@ void MainWindow::on_actionNewHiperbolic_triggered()
     if (!closeCurrentGraph())
         return;
     QString ret;
-    unsigned int n = intInputId("n:");
-    double a = doubleInputId("a:");
-    double deg = doubleInputId("deg:");
+    unsigned int n = intInputId("n:", 10000);
+    double a = doubleInputId("a:", 0.75);
+    double deg = doubleInputId("deg:", 0.0014);
 
     try
     {
@@ -2200,7 +2199,7 @@ void MainWindow::on_actionBoxplotCC_triggered()
         if (LogBinningDialog() == QMessageBox::Yes)
         {
             logBin = true;
-            bins = intInputId("bins:");
+            bins = intInputId("bins:", 10);
         }
 
         ret = this->console->boxplotCC(bpentries, logBin, bins);
@@ -2559,7 +2558,7 @@ void MainWindow::on_actionExportCCBoxplot_triggered()
         std::vector<graphpp::Boxplotentry> bpentries = this->computeBpentries();
         if (LogBinningDialog() == QMessageBox::Yes)
         {
-            bins = intInputId("bins:");
+            bins = intInputId("bins:", 10);
             LogBinningPolicy policy;
             policy.transform(bpentries, bins);
             std::vector<double> d, m;
@@ -2624,7 +2623,7 @@ void MainWindow::on_actionBoxplotNearestNeighborsDegree_triggered()
         if (LogBinningDialog() == QMessageBox::Yes)
         {
             logBin = true;
-            bins = intInputId("bins:");
+            bins = intInputId("bins:", 10);
         }
 
         ret = this->console->boxplotCC(bpentries, logBin, bins);
@@ -2719,7 +2718,7 @@ void MainWindow::on_actionExportKnnBoxplot_triggered()
         std::vector<graphpp::Boxplotentry> bpentries = this->computeBpentriesKnn();
         if (LogBinningDialog() == QMessageBox::Yes)
         {
-            bins = intInputId("bins:");
+            bins = intInputId("bins:", 10);
             LogBinningPolicy policy;
             policy.transform(bpentries, bins);
             std::vector<double> d, m;

--- a/src/gui/src/mainwindow.cpp
+++ b/src/gui/src/mainwindow.cpp
@@ -201,23 +201,8 @@ void MainWindow::on_actionExportPowerLawDegreeDistribution_triggered()
         return;
     }
 
-    QString inputN = inputId("alfa:");
-    if (inputN.isEmpty())
-    {
-        ui->textBrowser->append("Action canceled by user.");
-        return;
-    }
-
-    int alfa = inputN.toInt();
-
-    inputN = inputId("nodes:");
-    if (inputN.isEmpty())
-    {
-        ui->textBrowser->append("Action canceled by user.");
-        return;
-    }
-
-    int n = inputN.toInt();
+    int alfa = intInputId("alfa:");
+    int n = intInputId("nodes:");
 
     double dmax = pow(n, 1.0 / alfa);
     std::cout << "dmax: " << dmax << "\n";
@@ -440,6 +425,35 @@ QString MainWindow::inputId(std::string const& label)
     return ret;
 }
 
+int MainWindow::intInputId(std::string const& label)
+{
+    QString ret;
+    QInputDialog inputVertexIdDialog(this);
+    inputVertexIdDialog.setInputMode(QInputDialog::IntInput);
+    inputVertexIdDialog.setIntMinimum(0);
+    inputVertexIdDialog.setIntMaximum(INT_MAX);
+    inputVertexIdDialog.setLabelText(label.c_str());
+    inputVertexIdDialog.setCancelButtonText("Default = 0");
+    if (inputVertexIdDialog.exec())
+        return inputVertexIdDialog.intValue();
+    else
+        return 0;
+}
+
+double MainWindow::doubleInputId(std::string const& label)
+{
+    QString ret;
+    QInputDialog inputVertexIdDialog(this);
+    inputVertexIdDialog.setInputMode(QInputDialog::DoubleInput);
+    inputVertexIdDialog.setDoubleDecimals(8);
+    inputVertexIdDialog.setLabelText(label.c_str());
+    inputVertexIdDialog.setCancelButtonText("Default = 0.0");
+    if (inputVertexIdDialog.exec())
+        return inputVertexIdDialog.doubleValue();
+    else
+        return 0.0;
+}
+
 void MainWindow::on_actionExportMaxCliqueExact_distribution_triggered()
 {
     on_actionExportMaxClique_distribution_generic_triggered(true);
@@ -498,11 +512,7 @@ void MainWindow::on_action_maxClique_plotting_generic_triggered(bool exact)
     if (LogBinningDialog() == QMessageBox::Yes)
     {
         logBin = true;
-        QString inputN = inputId("bins:");
-        if (!inputN.isEmpty())
-        {
-            bins = inputN.toInt();
-        }
+        bins = intInputId("bins:");
     }
 
     bool ret = this->console->plotPropertySet(
@@ -723,11 +733,7 @@ void MainWindow::computeMaxClique(bool exact)
         int timeout = 0;
         if (exact)
         {
-            QString timeString = inputId("Time out (seconds):");
-            if (!timeString.isEmpty())
-            {
-                timeout = timeString.toInt();
-            }
+            timeout = intInputId("Time out (seconds):");
         }
         IMaxClique<Graph, Vertex>* maxClique =
             exact ? (IMaxClique<Graph, Vertex>*)factory->createExactMaxClique(graph, timeout)
@@ -995,11 +1001,7 @@ void MainWindow::on_actionDegree_distribution_plotting_triggered()
     if (LogBinningDialog() == QMessageBox::Yes)
     {
         logBin = true;
-        QString inputN = inputId("bins:");
-        if (!inputN.isEmpty())
-        {
-            bins = inputN.toInt();
-        }
+        bins = intInputId("bins:");
     }
     if (!this->digraph)
     {
@@ -1825,22 +1827,15 @@ void MainWindow::on_actionNewErdosRenyi_triggered()
     if (!closeCurrentGraph())
         return;
 
-    QString inputN = inputId("n:");
-    QString inputP = inputId("p:");
+    int n = intInputId("n:");
+    double p = doubleInputId("p:");
     QString ret;
 
-    unsigned int n = 1000;
-    float p = 0.1;
 
     try
     {
         this->onNetworkLoad(false, false, false);
         buildGraphFactory(false, false);
-
-        if (!inputN.isEmpty())
-            n = inputN.toInt();
-        if (!inputP.isEmpty())
-            p = inputP.toFloat();
 
         graph = *(GraphGenerator::getInstance()->generateErdosRenyiGraph(n, p));
 
@@ -1870,27 +1865,15 @@ void MainWindow::on_actionNewHiperbolic_triggered()
 {
     if (!closeCurrentGraph())
         return;
-
-    QString inputN = inputId("n:");
-    QString inputA = inputId("a:");
-    QString inputD = inputId("deg:");
     QString ret;
-
-    unsigned int n = 10000;
-    float a = 0.75;
-    float deg = 0.0014;
+    unsigned int n = intInputId("n:");
+    double a = doubleInputId("a:");
+    double deg = doubleInputId("deg:");
 
     try
     {
         this->onNetworkLoad(false, false, false);
         buildGraphFactory(false, false);
-
-        if (!inputN.isEmpty())
-            n = inputN.toInt();
-        if (!inputA.isEmpty())
-            a = inputA.toFloat();
-        if (!inputD.isEmpty())
-            deg = inputD.toFloat();
 
         QString text("Creating a network using a Papadopoulos hyperbolic graph algorithm...");
         text.append("\nexpected avg node deg: ");
@@ -2217,11 +2200,7 @@ void MainWindow::on_actionBoxplotCC_triggered()
         if (LogBinningDialog() == QMessageBox::Yes)
         {
             logBin = true;
-            QString inputN = inputId("bins:");
-            if (!inputN.isEmpty())
-            {
-                bins = inputN.toInt();
-            }
+            bins = intInputId("bins:");
         }
 
         ret = this->console->boxplotCC(bpentries, logBin, bins);
@@ -2580,11 +2559,7 @@ void MainWindow::on_actionExportCCBoxplot_triggered()
         std::vector<graphpp::Boxplotentry> bpentries = this->computeBpentries();
         if (LogBinningDialog() == QMessageBox::Yes)
         {
-            QString inputN = inputId("bins:");
-            if (!inputN.isEmpty())
-            {
-                bins = inputN.toInt();
-            }
+            bins = intInputId("bins:");
             LogBinningPolicy policy;
             policy.transform(bpentries, bins);
             std::vector<double> d, m;
@@ -2649,11 +2624,7 @@ void MainWindow::on_actionBoxplotNearestNeighborsDegree_triggered()
         if (LogBinningDialog() == QMessageBox::Yes)
         {
             logBin = true;
-            QString inputN = inputId("bins:");
-            if (!inputN.isEmpty())
-            {
-                bins = inputN.toInt();
-            }
+            bins = intInputId("bins:");
         }
 
         ret = this->console->boxplotCC(bpentries, logBin, bins);
@@ -2748,11 +2719,7 @@ void MainWindow::on_actionExportKnnBoxplot_triggered()
         std::vector<graphpp::Boxplotentry> bpentries = this->computeBpentriesKnn();
         if (LogBinningDialog() == QMessageBox::Yes)
         {
-            QString inputN = inputId("bins:");
-            if (!inputN.isEmpty())
-            {
-                bins = inputN.toInt();
-            }
+            bins = intInputId("bins:");
             LogBinningPolicy policy;
             policy.transform(bpentries, bins);
             std::vector<double> d, m;


### PR DESCRIPTION
## Summary
- commit aff0907: If you go to `File -> Open New Network...` if a graph is already opened, it now asks with a message box to close the current graph when trying to open a new one instead of forcing the user to close the graph by going to `File -> Close current network...`
- commit 4e1e23b: When creating, for example, a new Erdos-Renyi graph or by asking the user for any kind of number, you could input any text and the program would make a segmentation fault. Furthermore, the cancel button would not cancel but would default to an unkown value. This has been addressed by changing the tipe of QMessageBox and by adding two more functions which ask for an int or a double (and you can't input letters for example) and instead of showing the cancel button it shows a `Default = <defaultValue>`. It is up to the consumer of these functions to correctly handle the default value.

## Screenshots
<img width="595" alt="screen shot 2018-06-19 at 22 25 21" src="https://user-images.githubusercontent.com/9052089/41632553-dd67b6a4-7410-11e8-9cc6-119db6958708.png">
<img width="598" alt="screen shot 2018-06-19 at 22 14 17" src="https://user-images.githubusercontent.com/9052089/41632562-e3bcd12e-7410-11e8-85ea-688abbcd7a48.png">
<img width="597" alt="screen shot 2018-06-19 at 22 24 55" src="https://user-images.githubusercontent.com/9052089/41632563-e56427fc-7410-11e8-8c0e-298176f95ee1.png">

